### PR TITLE
Add Logging

### DIFF
--- a/lib/express-soap.ts
+++ b/lib/express-soap.ts
@@ -71,6 +71,7 @@ export function createSoapServer(router: Router, options: ISoapOptions): ISoapSe
 
   const wsdl = new WSDL(options.wsdl || options.xml || options.services, options.uri, options);
   const server: ISoapServer = Object.create(Server.prototype);
+  if(options.log) server.log = options.log;
   ExpressServerConstructor.call(server, router, options.services, wsdl);
 
   return server;

--- a/lib/interfaces/ISoapOptions.ts
+++ b/lib/interfaces/ISoapOptions.ts
@@ -19,6 +19,7 @@ export interface ISoapOptions {
   ignoreBaseNameSpaces?: any;
   forceSoap12Headers?: any;
   overrideRootElement?: any;
+  log?(type : string, data: any): any;
 
   [otherOption: string]: any;
 }


### PR DESCRIPTION
In the node-soap project, you can add logging by [attaching](https://github.com/vpulim/node-soap#server-logging) a `.log()` function to the server object. In this project, that's difficult because the base server object is never exposed to the caller. This PR allows users to pass in a log function matching the spec in vpulim/node-soap which will then be attached to the server object.

For example, I have this as options in my soap router:
```es6
const soap = expressSoap.soap({
    services : ReportService,
    wsdl : wsdl,
    log : (type, data) => log.info("SOAP LOG", {type: type, data : _.isString(data) ? data : JSON.stringify(data)})
})
```